### PR TITLE
Use platform specific names for called program executables, allow compilation on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build/
 # GBA ROM files
 
 *.gba
+
+# MacOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ CC=gcc -std=c99
 # Parameters used for compilation
 FLAGS=-Wall -fdata-sections -ffunction-sections -fmax-errors=5 -Os
 # Additional parameters used for linking whole programs
-WHOLE=-s -fwhole-program -static
+# On Linux / Windows
+#WHOLE=-s -fwhole-program -static
+# -static can't be used on MacOS
+WHOLE=-s -fwhole-program
 
 all: $(shell mkdir build) $(shell mkdir out) out/sappy_detector out/song_ripper out/sound_font_ripper out/gba_mus_ripper
 

--- a/gba_mus_ripper.cpp
+++ b/gba_mus_ripper.cpp
@@ -22,6 +22,17 @@ namespace sappy_detector
 {
     #include "sappy_detector.c"             // The main::function is called directly on Linux
 }
+
+#define GBA_MUS_RIPPER_NAME "gba_mus_ripper"
+#define SONG_RIPPER_NAME "song_ripper"
+#define SOUND_FRONT_RIPPER_NAME "sound_font_ripper"
+
+#else
+
+#define GBA_MUS_RIPPER_NAME "gba_mus_ripper.exe"
+#define SONG_RIPPER_NAME "song_ripper.exe"
+#define SOUND_FRONT_RIPPER_NAME "sound_font_ripper.exe"
+
 #endif
 
 static FILE *inGBA;
@@ -163,7 +174,7 @@ int main(int argc, char *const argv[])
 {
 	// Parse arguments (without program name)
 	parse_args(argc - 1, argv + 1);
-	
+
 	if (outPath.size() == 0)
 	{
 		outPath = ".";
@@ -171,7 +182,7 @@ int main(int argc, char *const argv[])
 
 	// Compute program prefix (should be "", "./", "../" or whathever)
 	std::string prg_name = argv[0];
-	std::string prg_prefix = prg_name.substr(0, prg_name.rfind("gba_mus_ripper.exe"));
+	std::string prg_prefix = prg_name.substr(0, prg_name.rfind(GBA_MUS_RIPPER_NAME));
 
 	int sample_rate = 0, main_volume = 0;		// Use default values when those are '0'
 
@@ -305,7 +316,7 @@ int main(int argc, char *const argv[])
 		if (song_list[i] != song_tbl_end_ptr)
 		{
 			unsigned int bank_index = distance(sound_bank_list.begin(), sound_bank_index_list[i]);
-			std::string seq_rip_cmd = prg_prefix + "song_ripper.exe \"" + inGBA_path + "\" \"" + outPath;
+			std::string seq_rip_cmd = prg_prefix + SONG_RIPPER_NAME + " \"" + inGBA_path + "\" \"" + outPath;
 
 			// Add leading zeroes to file name
 			if (sb) seq_rip_cmd += "/soundbank_" + dec4(bank_index);
@@ -339,7 +350,7 @@ int main(int argc, char *const argv[])
 
 			std::string sbnumber = dec4(bank_index);
 			std::string foldername = "soundbank_" + sbnumber;
-			std::string sf_rip_args = prg_prefix + "sound_font_ripper.exe \"" + inGBA_path + "\" \"" + outPath + '/';
+			std::string sf_rip_args = prg_prefix + SOUND_FRONT_RIPPER_NAME + " \"" + inGBA_path + "\" \"" + outPath + '/';
 			sf_rip_args += foldername + '/' + foldername /* + "_@" + hex(*j) */ + ".sf2\"";
 
 			if (sample_rate) sf_rip_args += " -s" + std::to_string(sample_rate);
@@ -356,7 +367,7 @@ int main(int argc, char *const argv[])
 		// Rips each sound bank in a single soundfont file
 		// Build argument list to call sound_font_riper
 		// Output sound font named after the input ROM
-		std::string sf_rip_args = prg_prefix + "sound_font_ripper.exe \"" + inGBA_path + "\" \"" + outPath + '/' + name + ".sf2\"";
+		std::string sf_rip_args = prg_prefix + SOUND_FRONT_RIPPER_NAME + " \"" + inGBA_path + "\" \"" + outPath + '/' + name + ".sf2\"";
 		if (sample_rate) sf_rip_args += " -s" + std::to_string(sample_rate);
 		if (main_volume) sf_rip_args += " -mv" + std::to_string(main_volume);
 		// Pass -gm argument if necessary

--- a/gba_mus_ripper.cpp
+++ b/gba_mus_ripper.cpp
@@ -9,6 +9,7 @@
  * instruments to SoundFont 2.0 (.sf2) format.
  */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/midi.cpp
+++ b/midi.cpp
@@ -71,7 +71,7 @@ void MIDI::write(FILE *out)
 		0x06000000,
 		0x0000,
 		0x0100,
-		(delta_time_per_beat << 8) | (delta_time_per_beat >> 8)
+		(uint16_t)(((delta_time_per_beat & 0x00ff) << 8) | ((delta_time_per_beat & 0xff00) >> 8))
 	};
 	fwrite(&mthd_chunk, 1, 14, out);
 

--- a/sf2.cpp
+++ b/sf2.cpp
@@ -30,7 +30,7 @@
 #include "gba_samples.hpp"
 
 //Constructor to change the default sample rate
-SF2::SF2(unsigned int sample_rate = 22050) :
+SF2::SF2(unsigned int sample_rate) :
 	size(0), /*instruments(this),*/
 	infolist_chunk(new InfoListChunk(this)),
 	sdtalist_chunk(new SdtaListChunk(this)),

--- a/sf2.hpp
+++ b/sf2.hpp
@@ -45,7 +45,7 @@ public:
 	FILE *out;
 	unsigned int default_sample_rate;
 
-	SF2(unsigned int sample_rate);
+	SF2(unsigned int sample_rate = 22050);
 	~SF2();
 	void write(FILE *outfile);
 	void add_new_preset(const char *name, int Patch, int Bank);


### PR DESCRIPTION
This PR has two main parts:

1. Some minor fixes and changes have been made to allow compilation on MacOS, mainly due to Clang (the default C / C++ compiler on MacOS) being pedantic. These changes should hopefully not alter any program behaviour.
2. At compile time, platform-specific names of the executable files called from gba_mus_ripper are used (the ".exe" prefix is used on Windows, and no prefix is used on other platforms). This should allow the program to run on Unix-like platforms (MacOS, Linux etc).

Disclaimer: only tested on MacOS 10.14.6. I'm also mainly a Java programmer, so I have less experience with C / C++. You should probably verify these changes to make sure that the program still works as expected. As part of allowing the program to compile on MacOS, I removed using the -static build flag by default. I'd be happy to change it back if you want to use it by default. You also might want to instead consider using make to detect which platform you are compiling for.

Fixes #11, fixes #13, supersedes #12.